### PR TITLE
Update minisat.cabal: Lower bound on async

### DIFF
--- a/minisat.cabal
+++ b/minisat.cabal
@@ -19,7 +19,7 @@ source-repository head
 
 library
   default-extensions: ForeignFunctionInterface
-  build-depends:   base >= 3 && < 5, async
+  build-depends:   base >= 3 && < 5, async >= 2.0.0.0
   C-sources:       minisat-c-bindings/minisat.cc
                    minisat/minisat/core/Solver.cc
                    minisat/minisat/simp/SimpSolver.cc


### PR DESCRIPTION
Following https://hackage.haskell.org/package/minisat/revisions/