### PR TITLE
Modernise C++ setup

### DIFF
--- a/minisat.cabal
+++ b/minisat.cabal
@@ -1,10 +1,10 @@
+cabal-version:   2.2
 name:            minisat
 version:         0.1.3
 build-type:      Simple
-cabal-version:   >= 1.10
 Synopsis:        A Haskell bundle of the Minisat SAT solver
 Category:        Logic
-License:         BSD3
+License:         BSD-3-Clause
 License-File:    LICENSE
 extra-source-files: minisat-c-bindings/minisat.h
                     minisat-haskell-bindings/hsc-magic.h
@@ -20,13 +20,32 @@ source-repository head
 library
   default-extensions: ForeignFunctionInterface
   build-depends:   base >= 3 && < 5, async >= 2.0.0.0
-  C-sources:       minisat-c-bindings/minisat.cc
+  cxx-sources:     minisat-c-bindings/minisat.cc
                    minisat/minisat/core/Solver.cc
                    minisat/minisat/simp/SimpSolver.cc
                    minisat/minisat/utils/System.cc
-  CC-options:      -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS
-  extra-libraries: stdc++
+  cc-options:      -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS
   hs-source-dirs:  minisat-haskell-bindings
   include-dirs:    minisat-haskell-bindings, minisat-c-bindings, minisat
   exposed-modules: MiniSat
   default-language: Haskell2010
+
+  -- stdc++ setup copied from text
+  -- https://hackage.haskell.org/package/text-2.1.2/text.cabal
+  if impl(ghc >= 9.4)
+    build-depends: system-cxx-std-lib == 1.0
+  elif os(darwin) || os(freebsd)
+    extra-libraries: c++
+  elif os(openbsd)
+    extra-libraries: c++ c++abi pthread
+  elif os(windows)
+    -- GHC's Windows toolchain is based on clang/libc++ in GHC 9.4 and later
+    if impl(ghc < 9.3)
+      extra-libraries: stdc++
+    else
+      extra-libraries: c++ c++abi
+  elif arch(wasm32)
+    cxx-options: -fno-exceptions
+    extra-libraries: c++ c++abi
+  else
+    extra-libraries: stdc++


### PR DESCRIPTION
Use correct cxx-sources, and more importantly system-cxx-std-lib when its available

See https://downloads.haskell.org/ghc/latest/docs/users_guide/packages.html#linking-against-c-libraries